### PR TITLE
Properly implement local variables

### DIFF
--- a/spec/js/class/instantiation_spec.cr
+++ b/spec/js/class/instantiation_spec.cr
@@ -37,11 +37,15 @@ module JS::Class::InstantiationSpec
         }
       }
 
-      var my_bar = "goo";
-      var my_class = new JS_Class_InstantiationSpec_MyFile_SomeClass("blah", my_bar);
+      var my_bar;
+      var my_class;
+      var my_foo;
+      var mem;
+      my_bar = "goo";
+      my_class = new JS_Class_InstantiationSpec_MyFile_SomeClass("blah", my_bar);
       my_class.do_something();
-      var my_foo = new Foo("bar");
-      var mem = new WebAssembly.Memory();
+      my_foo = new Foo("bar");
+      mem = new WebAssembly.Memory();
       JS
 
       MyFile.to_js.should eq(expected)

--- a/spec/js/code/anonymous_function_call_spec.cr
+++ b/spec/js/code/anonymous_function_call_spec.cr
@@ -12,7 +12,8 @@ module JS::Code::AnonymousFunctionCallSpec
   describe "MyJS.to_js" do
     it "should return the correct JS code" do
       expected = <<-JS.squish
-      var arr = Uint8Array.from("test", function(c) {
+      var arr;
+      arr = Uint8Array.from("test", function(c) {
         return c.charCodeAt(0);
       });
       JS

--- a/spec/js/code/assignment_spec.cr
+++ b/spec/js/code/assignment_spec.cr
@@ -5,14 +5,36 @@ module JS::Code::AssignmentSpec
     def_to_js do
       my_var = 1
       my_var += 1
+
+      bla = false
+      someArr = ["test", "blah", "foo"]
+      someArr.forEach do |item|
+        tmp = item
+        if !bla
+          console.log(tmp)
+          bla = true
+        end
+      end
     end
 
     describe "MyCode.to_js" do
       it "return the correct JS code" do
         expected = <<-JS.squish
         var my_var;
+        var bla;
+        var someArr;
         my_var = 1;
         my_var = my_var + 1;
+        bla = false;
+        someArr = ["test", "blah", "foo"];
+        someArr.forEach(function(item) {
+          var tmp;
+          tmp = item;
+          if (!bla) {
+            console.log(tmp);
+            bla = true;
+          }
+        });
         JS
 
         MyCode.to_js.should eq(expected)

--- a/spec/js/code/assignment_spec.cr
+++ b/spec/js/code/assignment_spec.cr
@@ -1,0 +1,22 @@
+require "../../spec_helper"
+
+module JS::Code::AssignmentSpec
+  class MyCode < JS::Code
+    def_to_js do
+      my_var = 1
+      my_var += 1
+    end
+
+    describe "MyCode.to_js" do
+      it "return the correct JS code" do
+        expected = <<-JS.squish
+        var my_var;
+        my_var = 1;
+        my_var = my_var + 1;
+        JS
+
+        MyCode.to_js.should eq(expected)
+      end
+    end
+  end
+end

--- a/spec/js/code/foreach_spec.cr
+++ b/spec/js/code/foreach_spec.cr
@@ -13,7 +13,8 @@ module JS::Code::ForeachSpec
   describe "MyJs.to_js" do
     it "should return the correct JS code" do
       expected = <<-JS.squish
-      var arr = ["this", "is", "sparta"];
+      var arr;
+      arr = ["this", "is", "sparta"];
       arr.forEach(function(item) {
         console.log(item);
       });

--- a/spec/js/code/hash_assignment_spec.cr
+++ b/spec/js/code/hash_assignment_spec.cr
@@ -15,9 +15,11 @@ module JS::Code::HashAssignmentSpec
   describe "MyCode.to_js" do
     it "should return the correct JS code" do
       expected = <<-JS.squish
-      var my_arr = new Uint8Array(20);
+      var my_arr;
+      var other_var;
+      my_arr = new Uint8Array(20);
       my_arr[7] = 14;
-      var other_var = 10;
+      other_var = 10;
       if (my_arr[7] > other_var) {
         console.log(my_arr[7]);
       }

--- a/spec/js/code/hash_literal_spec.cr
+++ b/spec/js/code/hash_literal_spec.cr
@@ -12,9 +12,12 @@ module JS::Code::HashLiteralSpec
   describe "MyCode.to_js" do
     it "should return the correct JS code" do
       expected = <<-JS.squish
-      var h1 = {};
-      var h2 = {test: "foo"};
-      var h3 = {blah: 1, gold: "digga"};
+      var h1;
+      var h2;
+      var h3;
+      h1 = {};
+      h2 = {test: "foo"};
+      h3 = {blah: 1, gold: "digga"};
       JS
 
       MyCode.to_js.should eq(expected)

--- a/spec/js/code/operator_spec.cr
+++ b/spec/js/code/operator_spec.cr
@@ -24,21 +24,31 @@ module JS::Code::OperatorSpec
   describe "MyCode.to_js" do
     it "should return the correct JS code" do
       expected = <<-JS.squish
-      var i = 10000;
-      var j = i * 20;
-      var y = j + 10;
-      var x = y - 2;
-      var z = x / 2;
-      var a = i * j * z + 4;
-      var b = 4 * 4;
+      var i;
+      var j;
+      var y;
+      var x;
+      var z;
+      var a;
+      var b;
+
+      i = 10000;
+      j = i * 20;
+      y = j + 10;
+      x = y - 2;
+      z = x / 2;
+      a = i * j * z + 4;
+      b = 4 * 4;
       if ((x > 0 && x >= y) || (x < 0 && x <= y)) {
         console.log("yes");
       }
       if (a == b) {
-        var c = a;
+        var c;
+        c = a;
       }
       if (x >= j) {
-        var d = x;
+        var d;
+        d = x;
       }
       JS
 

--- a/spec/js/code/operator_spec.cr
+++ b/spec/js/code/operator_spec.cr
@@ -16,8 +16,8 @@ module JS::Code::OperatorSpec
       if x > 0 && x >= y || x < 0 && x <= y
         console.log("yes")
       end
-      c = a if a == b
-      d = x if x >= j
+      z += 1 if a == b
+      x -= 1 if x >= j
     end
   end
 
@@ -43,12 +43,10 @@ module JS::Code::OperatorSpec
         console.log("yes");
       }
       if (a == b) {
-        var c;
-        c = a;
+        z = z + 1;
       }
       if (x >= j) {
-        var d;
-        d = x;
+        x = x - 1;
       }
       JS
 

--- a/spec/js/code/operator_spec.cr
+++ b/spec/js/code/operator_spec.cr
@@ -29,7 +29,7 @@ module JS::Code::OperatorSpec
       var y = j + 10;
       var x = y - 2;
       var z = x / 2;
-      var a = ((i * j) * z) + 4;
+      var a = i * j * z + 4;
       var b = 4 * 4;
       if ((x > 0 && x >= y) || (x < 0 && x <= y)) {
         console.log("yes");

--- a/src/js/code.cr
+++ b/src/js/code.cr
@@ -22,6 +22,12 @@ module JS
 
     macro _eval_js_block(io, namespace, nested = false, &blk)
       {% if blk.body.is_a?(Expressions) %}
+        {% for var in blk.body.expressions.select { |e| e.is_a?(Assign) }.map { |a| a.target.stringify }.uniq %}
+          {{io}} << "var "
+          {{io}} << {{var}}
+          {{io}} << ";"
+        {% end %}
+
         {% for exp in blk.body.expressions %}
           {% if exp.is_a?(Call) && exp.name.stringify == "_literal_js" %}
             {{io}} << {{exp.args.first}}

--- a/src/js/code.cr
+++ b/src/js/code.cr
@@ -44,7 +44,7 @@ module JS
         {{io}} << {{blk.body}}
       {% elsif blk.body.is_a?(Call) && blk.body.name.stringify == "new" %}
         {{io}} << "new "
-        JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.receiver}}
         end
         {{io}} << "("
@@ -60,7 +60,7 @@ module JS
       {% elsif blk.body.is_a?(Call) && blk.body.name.stringify == "[]" %}
         {{io}} << {{blk.body.receiver.stringify}}
         {{io}} << "["
-        JS::Code._eval_js({{io}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.args.first}}
         end
         {{io}} << "]"
@@ -70,11 +70,11 @@ module JS
       {% elsif blk.body.is_a?(Call) && blk.body.name.stringify == "[]=" %}
         {{io}} << {{blk.body.receiver.stringify}}
         {{io}} << "["
-        JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.args.first}}
         end
         {{io}} << "] = "
-        JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.args.last}}
         end
         {% if !nested %}
@@ -85,7 +85,7 @@ module JS
         {{io}} << "."
         {{io}} << {{blk.body.name.stringify[0..-2]}}
         {{io}} << " = "
-        JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.args.first}}
         end
         {% if !nested %}
@@ -93,13 +93,13 @@ module JS
         {% end %}
       {% elsif blk.body.is_a?(Call) %}
         {% if blk.body.receiver && blk.body.args.size == 1 && OPERATOR_CALL_NAMES.includes?(blk.body.name.stringify) %}
-          JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+          JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
             {{blk.body.receiver}}
           end
           {{io}} << " "
           {{io}} << {{blk.body.name.stringify}}
           {{io}} << " "
-          JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+          JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
             {{blk.body.args.first}}
           end
         {% else %}
@@ -177,7 +177,7 @@ module JS
         {% for key, i in blk.body.keys %}
           {{io}} << {{key.id.stringify}}
           {{io}} << ": "
-          JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+          JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
             {{blk.body[key]}}
           end
           {% if i < blk.body.size - 1 %}
@@ -190,7 +190,7 @@ module JS
         {% end %}
       {% elsif blk.body.is_a?(If) %}
         {{io}} << "if ("
-        JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.cond}}
         end
         {{io}} << ") {"
@@ -209,7 +209,7 @@ module JS
         {{io}} << "var "
         {{io}} << {{blk.body.target.stringify}}
         {{io}} << " = "
-        JS::Code._eval_js({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.value}}
         end
         {% if !nested %}
@@ -217,7 +217,7 @@ module JS
         {% end %}
       {% elsif blk.body.is_a?(Return) %}
         {{io}} << "return "
-        JS::Code._eval_js({{io}}, {{namespace}}) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+        JS::Code._eval_js_block({{io}}, {{namespace}}) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
           {{blk.body.exp}}
         end
       {% elsif blk.body.is_a?(MacroIf) %}

--- a/src/js/code.cr
+++ b/src/js/code.cr
@@ -49,7 +49,7 @@ module JS
         end
         {{io}} << "("
         {% for arg, index in blk.body.args %}
-          JS::Code._eval_js_arg({{io}}) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+          JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
             {{arg}}
           end
           {% if index < blk.body.args.size - 1 %}
@@ -135,7 +135,7 @@ module JS
             {{io}} << "("
           {% end %}
           {% for arg, index in blk.body.args %}
-            JS::Code._eval_js_arg({{io}}) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, true) do {{ blk.args.empty? ? "".id : "|#{blk.args.splat}|".id }}
               {{arg}}
             end
             {% if index < blk.body.args.size - 1 || blk.body.block %}
@@ -238,22 +238,6 @@ module JS
         \{% end %}
       {% elsif blk.body.is_a?(MacroExpression) || blk.body.is_a?(MacroLiteral) %}
         {{blk.body}}
-      {% else %}
-        {{io}} << {{blk.body.stringify}}
-      {% end %}
-    end
-
-    macro _eval_js_arg(io, &blk)
-      {% if blk.body.is_a?(Call) && blk.body.name.stringify == "_literal_js" %}
-        {{io}} << {{blk.body.args.first}}
-      {% elsif blk.body.is_a?(Call) && (blk.body.name.stringify == "to_js_ref" || blk.body.name.stringify == "to_js_call") %}
-        {{io}} << {{blk.body}}
-      {% elsif (blk.body.is_a?(Path) || blk.body.is_a?(TypeNode)) %}
-        if {{blk.body}}.responds_to?(:to_js_ref)
-          {{io}} << {{blk.body}}.to_js_ref
-        else
-          {{io}} << {{blk.body.stringify}}
-        end
       {% else %}
         {{io}} << {{blk.body.stringify}}
       {% end %}

--- a/src/js/file.cr
+++ b/src/js/file.cr
@@ -45,7 +45,7 @@ module JS
         @@js_functions.each do |func|
           func.to_js(io)
         end
-        JS::Code._eval_js_block(io, {{namespace}}) {{blk}}
+        JS::Code._eval_js_block(io, {{namespace}}, {inline: false}) {{blk}}
       end
 
       def self.to_js

--- a/src/js/file.cr
+++ b/src/js/file.cr
@@ -45,7 +45,7 @@ module JS
         @@js_functions.each do |func|
           func.to_js(io)
         end
-        JS::Code._eval_js_block(io, {{namespace}}, {inline: false}) {{blk}}
+        JS::Code._eval_js_block(io, {{namespace}}, {inline: false, nested_scope: true}) {{blk}}
       end
 
       def self.to_js

--- a/src/js/file.cr
+++ b/src/js/file.cr
@@ -34,6 +34,10 @@ module JS
     end
 
     macro def_to_js(&blk)
+      def_to_js({{@type}}) {{blk}}
+    end
+
+    macro def_to_js(namespace, &blk)
       def self.to_js(io : IO)
         @@js_classes.each do |js_class|
           js_class.to_js(io)
@@ -41,7 +45,7 @@ module JS
         @@js_functions.each do |func|
           func.to_js(io)
         end
-        JS::Code._eval_js_block(io, {{@type}}) {{blk}}
+        JS::Code._eval_js_block(io, {{namespace}}) {{blk}}
       end
 
       def self.to_js

--- a/src/js/module.cr
+++ b/src/js/module.cr
@@ -9,7 +9,7 @@ module JS
     end
 
     macro def_to_js(&blk)
-      JS::File.def_to_js {{blk}}
+      JS::File.def_to_js({{@type}}) {{blk}}
 
       def self.to_js(io : IO)
         @@js_imports.join(io, "\n")


### PR DESCRIPTION
Before these changes, a local variable could not be reassigned, as the transpiler would always prepend a `var ` before each assignment. This was not valid JavaScript.
```crystal
def_to_js do
  x = 1
  x += 1
end
```
Before:
```javascript
var x = 1;
var x = x + 1;
```
After:
```javascript
var x;
x = 1;
x = x + 1;
```