### PR TITLE
Support assignment of dynamic Crystal arrays to static JS properties

### DIFF
--- a/spec/js/class/static_property_spec.cr
+++ b/spec/js/class/static_property_spec.cr
@@ -4,6 +4,7 @@ module JS::Class::StaticPropertySpec
   class MyClass < JS::Class
     static things = ["one_thing", "another_thing"]
     static dynamic_things = [JS::Class.name, JS::Code.name]
+    static object_with_classes = {str: String, int: Int, obj: Object, bool: Bool, arr: Array}
   end
 
   describe "MyClass.to_js" do
@@ -12,6 +13,7 @@ module JS::Class::StaticPropertySpec
       class JS_Class_StaticPropertySpec_MyClass {
         static things = ["one_thing", "another_thing"];
         static dynamic_things = ["JS::Class", "JS::Code"];
+        static object_with_classes = {str: String, int: Number, obj: Object, bool: Boolean, arr: Array};
       }
       JS
 

--- a/spec/js/class/static_property_spec.cr
+++ b/spec/js/class/static_property_spec.cr
@@ -3,6 +3,7 @@ require "../../spec_helper"
 module JS::Class::StaticPropertySpec
   class MyClass < JS::Class
     static things = ["one_thing", "another_thing"]
+    static dynamic_things = [JS::Class.name, JS::Code.name]
   end
 
   describe "MyClass.to_js" do
@@ -10,6 +11,7 @@ module JS::Class::StaticPropertySpec
       expected = <<-JS.squish
       class JS_Class_StaticPropertySpec_MyClass {
         static things = ["one_thing", "another_thing"];
+        static dynamic_things = ["JS::Class", "JS::Code"];
       }
       JS
 

--- a/src/ext/array.cr
+++ b/src/ext/array.cr
@@ -1,0 +1,5 @@
+class Array(T)
+  def to_js_ref
+    "[#{self.map(&.to_js_ref).join(", ")}]"
+  end
+end

--- a/src/ext/array.cr
+++ b/src/ext/array.cr
@@ -1,4 +1,8 @@
 class Array(T)
+  def self.to_js_ref
+    "Array"
+  end
+
   def to_js_ref
     "[#{self.map(&.to_js_ref).join(", ")}]"
   end

--- a/src/ext/bool.cr
+++ b/src/ext/bool.cr
@@ -1,0 +1,5 @@
+struct Bool
+  def self.to_js_ref
+    "Boolean"
+  end
+end

--- a/src/ext/int.cr
+++ b/src/ext/int.cr
@@ -1,4 +1,8 @@
 struct Int
+  def self.to_js_ref
+    "Number"
+  end
+
   def to_js_ref
     self
   end

--- a/src/ext/named_tuple.cr
+++ b/src/ext/named_tuple.cr
@@ -1,0 +1,15 @@
+struct NamedTuple
+  def self.to_js_ref
+    "Object"
+  end
+
+  def to_js_ref
+    String.build do |str|
+      str << "{"
+      self.map do |key, value|
+        "#{key}: #{value.to_js_ref}"
+      end.join(str, ", ")
+      str << "}"
+    end
+  end
+end

--- a/src/ext/object.cr
+++ b/src/ext/object.cr
@@ -1,0 +1,5 @@
+class Object
+  def self.to_js_ref
+    name
+  end
+end

--- a/src/ext/string.cr
+++ b/src/ext/string.cr
@@ -1,4 +1,8 @@
 class String
+  def self.to_js_ref
+    "String"
+  end
+
   def to_js_ref
     self.dump
   end

--- a/src/js/class.cr
+++ b/src/js/class.cr
@@ -4,7 +4,7 @@ require "./method"
 module JS
   abstract class Class
     @@js_extends : String?
-    @@static_properties = [] of String
+    @@static_properties = [] of Tuple(String, String)
     @@js_methods = [] of JS::Method.class
 
     def self.class_name
@@ -16,7 +16,7 @@ module JS
     end
 
     macro static(assignment)
-      @@static_properties << {{assignment.stringify}}
+      @@static_properties << { {{assignment.target.stringify}}, {{assignment.value}}.to_js_ref }
     end
 
     macro js_method(name, &blk)
@@ -43,9 +43,11 @@ module JS
         io << @@js_extends
       end
       io << " {"
-      @@static_properties.each do |prop|
+      @@static_properties.each do |(name, value)|
         io << "static "
-        io << prop
+        io << name
+        io << " = "
+        io << value
         io << ";"
       end
       @@js_methods.each do |js_method|


### PR DESCRIPTION
Additionally ensuring a StimulusJS `values` hash can still be provided as a NamedTuple with the type classes as values.