### PR TITLE
Transpile nil to undefined

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/js.cr` is the shard entrypoint; core types live under `src/js/` (e.g., `code.cr`, `function.cr`, `class.cr`, `module.cr`, `file.cr`, `method.cr`).
+- `src/ext/` contains Crystal core extensions used by the JS builders.
+- `spec/` holds tests and helpers (see `spec/spec_helper.cr`).
+
+## Build, Test, and Development Commands
+- `shards install` — install Crystal shard dependencies (none currently, but keep in sync with `shard.yml`).
+- `crystal spec` — run the full test suite; `crystal spec spec/<file>_spec.cr` for a focused run.
+- `crystal spec --error-trace` — helpful when debugging macro or compiler errors.
+- `crystal tool format` or `crystal tool format --check src spec` — format and verify style before PRs.
+- `crystal build src/js.cr -o bin/js` — optional local build if you want a compiled artifact.
+
+## Coding Style & Naming Conventions
+- Follow standard Crystal formatting: 2-space indentation, LF line endings, final newline; rely on `crystal tool format`.
+- Naming: `CamelCase` for modules/classes/types; `snake_case` for files, methods, and variables.
+- Prefer self-descriptive names; document public APIs only when behavior is non-obvious.
+- JS output is intentionally whitespace-light; specs often normalize with `String#squish` (see `spec/spec_helper.cr`).
+
+## Testing Guidelines
+- Use Crystal’s `spec` framework; place specs in `spec/` and name files `*_spec.cr`.
+- Keep examples minimal and deterministic; cover the happy path plus one failure/edge case where feasible.

--- a/spec/js/code/nil_spec.cr
+++ b/spec/js/code/nil_spec.cr
@@ -1,0 +1,29 @@
+require "../../spec_helper"
+
+module JS::Code::NilSpec
+  class NilCode < JS::Code
+    def_to_js do
+      obj.some_prop = nil
+      console.log(nil)
+      arr = [nil, 1]
+      hash = {foo: nil}
+      nil
+    end
+  end
+
+  describe "NilCode.to_js" do
+    it "transpiles nil to undefined" do
+      expected = <<-JS.squish
+      var arr;
+      var hash;
+      obj.some_prop = undefined;
+      console.log(undefined);
+      arr = [undefined, 1];
+      hash = {foo: undefined};
+      undefined;
+      JS
+
+      NilCode.to_js.should eq(expected)
+    end
+  end
+end

--- a/spec/js/function/basic_spec.cr
+++ b/spec/js/function/basic_spec.cr
@@ -45,5 +45,13 @@ module JS::Function::BasicSpec
 
       FunctionCode.to_js_call(2, 3).should eq(expected)
     end
+
+    it "should map nil to undefined" do
+      expected = <<-JS
+      my_func(undefined, "maah")
+      JS
+
+      FunctionCode.to_js_call(nil, "maah").should eq(expected)
+    end
   end
 end

--- a/src/js/function.cr
+++ b/src/js/function.cr
@@ -10,7 +10,9 @@ module JS
         str << function_name
         str << "("
         args.join(str, ", ") do |arg|
-          if arg.is_a?(String)
+          if arg.nil?
+            str << "undefined"
+          elsif arg.is_a?(String)
             str << "\"#{arg}\""
           else
             str << arg


### PR DESCRIPTION
Any `nil` values from Crystal were previously ignored, and there was no way to actually get an `undefined` in JS. This gap is now closed.
Also added an initial AGENTS.md in the process, don't mind it.