### PR TITLE
Always call #to_js_ref on Crystal objects implicitly

### DIFF
--- a/spec/js/class/static_property_spec.cr
+++ b/spec/js/class/static_property_spec.cr
@@ -4,7 +4,7 @@ module JS::Class::StaticPropertySpec
   class MyClass < JS::Class
     static things = ["one_thing", "another_thing"]
     static dynamic_things = [JS::Class.name, JS::Code.name]
-    static object_with_classes = {str: String, int: Int, obj: Object, bool: Bool, arr: Array}
+    static object_with_classes = {str: String, int: Int, obj: JS::Object, bool: Bool, arr: Array}
   end
 
   describe "MyClass.to_js" do

--- a/spec/js/code/native_to_js_ref_spec.cr
+++ b/spec/js/code/native_to_js_ref_spec.cr
@@ -10,6 +10,18 @@ module JS::Code::NativeToJsRefSpec
     end
   end
 
+  class CallValue
+    def to_js_ref
+      "from_call".dump
+    end
+  end
+
+  class Provider
+    def next_value
+      CallValue.new
+    end
+  end
+
   class MyCode < JS::Code
     STR_VALUE   = "hello"
     INT_VALUE   = 12
@@ -17,6 +29,14 @@ module JS::Code::NativeToJsRefSpec
     FLOAT_VALUE = 1.5
     ARRAY_VALUE = [1, "two", false]
     TUPLE_VALUE = {foo: "bar", count: 2, flag: true}
+
+    def self.call_value
+      CallValue.new
+    end
+
+    def self.complex_value
+      Provider.new.next_value
+    end
 
     def_to_js do
       console.log(STR_VALUE)
@@ -31,6 +51,10 @@ module JS::Code::NativeToJsRefSpec
       console.log(2.25)
       console.log([1, "two"])
       console.log({foo: "bar", count: 3})
+      console.log(call_value)
+      console.log(Provider.new.next_value)
+      js_var = "local"
+      console.log(js_var, complex_value)
       console.log(ExplicitClass)
       console.log(DemoJsClass)
     end
@@ -39,6 +63,7 @@ module JS::Code::NativeToJsRefSpec
   describe "MyCode.to_js" do
     it "should use to_js_ref for native calls" do
       expected = <<-JS.squish
+      var js_var;
       console.log("hello");
       console.log(12);
       console.log(true);
@@ -51,6 +76,10 @@ module JS::Code::NativeToJsRefSpec
       console.log(2.25);
       console.log([1, "two"]);
       console.log({foo: "bar", count: 3});
+      console.log("from_call");
+      console.log("from_call");
+      js_var = "local";
+      console.log(js_var, "from_call");
       console.log(ExplicitClass);
       console.log(JS_Code_NativeToJsRefSpec_DemoJsClass);
       JS

--- a/spec/js/code/native_to_js_ref_spec.cr
+++ b/spec/js/code/native_to_js_ref_spec.cr
@@ -1,0 +1,61 @@
+require "../../spec_helper"
+
+module JS::Code::NativeToJsRefSpec
+  class DemoJsClass < JS::Class
+  end
+
+  class ExplicitClass
+    def self.to_js_ref
+      "ExplicitClass"
+    end
+  end
+
+  class MyCode < JS::Code
+    STR_VALUE   = "hello"
+    INT_VALUE   = 12
+    BOOL_VALUE  = true
+    FLOAT_VALUE = 1.5
+    ARRAY_VALUE = [1, "two", false]
+    TUPLE_VALUE = {foo: "bar", count: 2, flag: true}
+
+    def_to_js do
+      console.log(STR_VALUE)
+      console.log(INT_VALUE)
+      console.log(BOOL_VALUE)
+      console.log(FLOAT_VALUE)
+      console.log(ARRAY_VALUE)
+      console.log(TUPLE_VALUE)
+      console.log("direct")
+      console.log(99)
+      console.log(false)
+      console.log(2.25)
+      console.log([1, "two"])
+      console.log({foo: "bar", count: 3})
+      console.log(ExplicitClass)
+      console.log(DemoJsClass)
+    end
+  end
+
+  describe "MyCode.to_js" do
+    it "should use to_js_ref for native calls" do
+      expected = <<-JS.squish
+      console.log("hello");
+      console.log(12);
+      console.log(true);
+      console.log(1.5);
+      console.log([1, "two", false]);
+      console.log({foo: "bar", count: 2, flag: true});
+      console.log("direct");
+      console.log(99);
+      console.log(false);
+      console.log(2.25);
+      console.log([1, "two"]);
+      console.log({foo: "bar", count: 3});
+      console.log(ExplicitClass);
+      console.log(JS_Code_NativeToJsRefSpec_DemoJsClass);
+      JS
+
+      MyCode.to_js.should eq(expected)
+    end
+  end
+end

--- a/src/ext/bool.cr
+++ b/src/ext/bool.cr
@@ -2,4 +2,8 @@ struct Bool
   def self.to_js_ref
     "Boolean"
   end
+
+  def to_js_ref
+    self
+  end
 end

--- a/src/ext/float.cr
+++ b/src/ext/float.cr
@@ -1,0 +1,19 @@
+struct Float32
+  def self.to_js_ref
+    "Number"
+  end
+
+  def to_js_ref
+    self
+  end
+end
+
+struct Float64
+  def self.to_js_ref
+    "Number"
+  end
+
+  def to_js_ref
+    self
+  end
+end

--- a/src/ext/object.cr
+++ b/src/ext/object.cr
@@ -1,5 +1,0 @@
-class Object
-  def self.to_js_ref
-    name
-  end
-end

--- a/src/js.cr
+++ b/src/js.cr
@@ -1,2 +1,3 @@
 require "./js/module"
+require "./js/object"
 require "./ext/*"

--- a/src/js/code.cr
+++ b/src/js/code.cr
@@ -195,11 +195,11 @@ module JS
           {% elsif exp.is_a?(Path) %}
             {% parent_namespace = namespace.stringify.split("::")[0..-2].join("::").id %}
             {% relative_path = exp.global? ? exp.stringify.gsub(/\A::/, "") : exp %}
-            {% if (type = exp.resolve?) && type.class.has_method?("to_js_ref") %}
+            {% if exp.resolve? %}
               {{io}} << {{exp}}.to_js_ref
-            {% elsif (type = parse_type("#{namespace}::#{relative_path.id}").resolve?) && type.class.has_method?("to_js_ref") %}
+            {% elsif (type = parse_type("#{namespace}::#{relative_path.id}").resolve?) %}
               {{io}} << {{type}}.to_js_ref
-            {% elsif (type = parse_type("#{parent_namespace}::#{relative_path.id}").resolve?) && type.class.has_method?("to_js_ref") %}
+            {% elsif (type = parse_type("#{parent_namespace}::#{relative_path.id}").resolve?) %}
               {{io}} << {{type}}.to_js_ref
             {% else %}
               {{io}} << {{exp.stringify}}

--- a/src/js/function.cr
+++ b/src/js/function.cr
@@ -12,10 +12,8 @@ module JS
         args.join(str, ", ") do |arg|
           if arg.nil?
             str << "undefined"
-          elsif arg.is_a?(String)
-            str << "\"#{arg}\""
           else
-            str << arg
+            str << arg.to_js_ref
           end
         end
         str << ")"

--- a/src/js/object.cr
+++ b/src/js/object.cr
@@ -1,0 +1,7 @@
+module JS
+  class Object
+    def self.to_js_ref
+      "Object"
+    end
+  end
+end


### PR DESCRIPTION
In `v2.0.0`, using an existing Crystal object that doesn't implement `#to_js_ref` will lead to a compiler error. Currently, the evaluation macro would fall back to #to_s, which usually leads to broken JS code.
As long as a `Path` used within the macro isn't resolvable, we keep assuming you mean a JS constant and use it as is.