### PR TITLE
Add let/const declaration DSL for def_to_js scope handling

### DIFF
--- a/spec/js/code/declaration_spec.cr
+++ b/spec/js/code/declaration_spec.cr
@@ -31,6 +31,19 @@ module JS::Code::DeclarationSpec
     end
   end
 
+  class NestedCallbackDeclarationCode < JS::Code
+    def_to_js do
+      let count = 0
+      const label = "tick"
+
+      setTimeout do
+        count = count + 1
+        console.log(label)
+        console.log(count)
+      end
+    end
+  end
+
   describe "let / const declarations" do
     it "emits let and const declarations at the declaration site" do
       expected = <<-JS.squish
@@ -81,6 +94,21 @@ module JS::Code::DeclarationSpec
       exit_code.should_not eq(0)
       stderr.should contain("requires an initializer")
       stderr.should contain("const my_var = value")
+    end
+
+    it "keeps let/const bindings available inside nested callback functions" do
+      expected = <<-JS.squish
+      let count = 0;
+      const label = "tick";
+      setTimeout(function() {
+        count = count + 1;
+        console.log(label);
+        console.log(count);
+      });
+      JS
+
+      NestedCallbackDeclarationCode.to_js.should eq(expected)
+      NestedCallbackDeclarationCode.to_js.should_not contain("var count;")
     end
   end
 end

--- a/spec/js/code/declaration_spec.cr
+++ b/spec/js/code/declaration_spec.cr
@@ -1,0 +1,86 @@
+require "../../spec_helper"
+
+module JS::Code::DeclarationSpec
+  class DeclarationCode < JS::Code
+    def_to_js do
+      let branch_value
+      if condition
+        branch_value = "available"
+      end
+      console.log(branch_value)
+
+      let pending
+      pending = true
+      console.log(pending)
+
+      let counter = 0
+      counter = counter + 1
+
+      const label = "stable"
+      console.log(label)
+    end
+  end
+
+  class StrictDeclarationCode < JS::Code
+    def_to_js strict: true do
+      let maybe_value
+      console.log(maybe_value)
+
+      const fixed_value = "fixed"
+      console.log(fixed_value)
+    end
+  end
+
+  describe "let / const declarations" do
+    it "emits let and const declarations at the declaration site" do
+      expected = <<-JS.squish
+      let branch_value;
+      if (condition) {
+        branch_value = "available";
+      }
+      console.log(branch_value);
+      let pending;
+      pending = true;
+      console.log(pending);
+      let counter = 0;
+      counter = counter + 1;
+      const label = "stable";
+      console.log(label);
+      JS
+
+      DeclarationCode.to_js.should eq(expected)
+      DeclarationCode.to_js.should_not contain("var pending;")
+      DeclarationCode.to_js.should_not contain("var counter;")
+    end
+
+    it "keeps declared variables usable in strict mode" do
+      expected = <<-JS.squish
+      let maybe_value;
+      console.log(maybe_value);
+      const fixed_value = "fixed";
+      console.log(fixed_value);
+      JS
+
+      StrictDeclarationCode.to_js.should eq(expected)
+    end
+
+    it "fails at compile-time when const has no initializer" do
+      source = <<-CR
+      require "./src/js"
+
+      class InvalidConstCode < JS::Code
+        def_to_js do
+          const declared_without_value
+        end
+      end
+
+      puts InvalidConstCode.to_js
+      CR
+
+      exit_code, _stdout, stderr = crystal_eval(source)
+      exit_code.should_not eq(0)
+      stderr.should contain("requires an initializer")
+      stderr.should contain("const my_var = value")
+    end
+  end
+end

--- a/spec/js/code/declaration_spec.cr
+++ b/spec/js/code/declaration_spec.cr
@@ -36,11 +36,11 @@ module JS::Code::DeclarationSpec
       let count = 0
       const label = "tick"
 
-      setTimeout do
+      setTimeout(-> {
         count = count + 1
         console.log(label)
         console.log(count)
-      end
+      }, 1000)
     end
   end
 
@@ -119,11 +119,11 @@ module JS::Code::DeclarationSpec
       expected = <<-JS.squish
       let count = 0;
       const label = "tick";
-      setTimeout(function() {
+      setTimeout(() => {
         count = count + 1;
         console.log(label);
         console.log(count);
-      });
+      }, 1000);
       JS
 
       NestedCallbackDeclarationCode.to_js.should eq(expected)

--- a/spec/js/code/declaration_spec.cr
+++ b/spec/js/code/declaration_spec.cr
@@ -96,6 +96,25 @@ module JS::Code::DeclarationSpec
       stderr.should contain("const my_var = value")
     end
 
+    it "fails at compile-time when using two call arguments" do
+      source = <<-CR
+      require "./src/js"
+
+      class InvalidLetCallStyleCode < JS::Code
+        def_to_js do
+          let(my_var, 1)
+        end
+      end
+
+      puts InvalidLetCallStyleCode.to_js
+      CR
+
+      exit_code, _stdout, stderr = crystal_eval(source)
+      exit_code.should_not eq(0)
+      stderr.should contain("accepts exactly one argument")
+      stderr.should contain("let my_var = value")
+    end
+
     it "keeps let/const bindings available inside nested callback functions" do
       expected = <<-JS.squish
       let count = 0;

--- a/src/js/code.cr
+++ b/src/js/code.cr
@@ -1,6 +1,7 @@
 module JS
   abstract class Code
-    OPERATOR_CALL_NAMES = %w[+ - * / ** ^ // & | && || > >= < <= == !=]
+    OPERATOR_CALL_NAMES             = %w[+ - * / ** ^ // & | && || > >= < <= == !=]
+    VARIABLE_DECLARATION_CALL_NAMES = %w[let const]
 
     JS_ALIASES = {} of String => String
 
@@ -38,7 +39,7 @@ module JS
         {% var_declaration_exclusions << declared_var %}
       {% end %}
       {% for exp in exps %}
-        {% if exp.is_a?(Call) && !exp.receiver && (exp.name.stringify == "let" || exp.name.stringify == "const") && exp.args.size > 0 %}
+        {% if exp.is_a?(Call) && !exp.receiver && VARIABLE_DECLARATION_CALL_NAMES.includes?(exp.name.stringify) && exp.args.size > 0 %}
           {% first_arg = exp.args.first %}
           {% if first_arg.is_a?(Assign) && first_arg.target.is_a?(Var) %}
             {% var_declaration_exclusions << first_arg.target.stringify %}
@@ -59,7 +60,7 @@ module JS
       {% end %}
 
       {% for exp in exps %}
-          {% if exp.is_a?(Call) && !exp.receiver && (exp.name.stringify == "let" || exp.name.stringify == "const") %}
+          {% if exp.is_a?(Call) && !exp.receiver && VARIABLE_DECLARATION_CALL_NAMES.includes?(exp.name.stringify) %}
             {% declaration_kind = exp.name.stringify %}
             {% if exp.args.empty? %}
               {{exp.raise "`#{declaration_kind}` requires a variable name. Use `#{declaration_kind} my_var = value`."}}

--- a/src/js/code.cr
+++ b/src/js/code.cr
@@ -13,7 +13,7 @@ module JS
         JS::Code._eval_js_block(
           io,
           {{@type.resolve}},
-          {inline: false, nested_scope: true, strict: {{strict}}}
+          {inline: false, nested_scope: true, strict: {{strict}}, declared_vars: [] of String}
         ) {{blk}}
       end
 
@@ -26,9 +26,32 @@ module JS
 
     macro _eval_js_block(io, namespace, opts, &blk)
       {% exps = blk.body.is_a?(Expressions) ? blk.body.expressions : [blk.body] %}
+      {% scope_declared_vars = [] of String %}
+      {% for declared_var in opts[:declared_vars] %}
+        {% scope_declared_vars << declared_var %}
+      {% end %}
+
+      # Collect declared names in this scope up front to avoid emitting duplicate
+      # `var` declarations for variables that are explicitly introduced via `let`/`const`.
+      {% var_declaration_exclusions = [] of String %}
+      {% for declared_var in scope_declared_vars %}
+        {% var_declaration_exclusions << declared_var %}
+      {% end %}
+      {% for exp in exps %}
+        {% if exp.is_a?(Call) && !exp.receiver && (exp.name.stringify == "let" || exp.name.stringify == "const") && exp.args.size > 0 %}
+          {% first_arg = exp.args.first %}
+          {% if first_arg.is_a?(Assign) && first_arg.target.is_a?(Var) %}
+            {% var_declaration_exclusions << first_arg.target.stringify %}
+          {% elsif first_arg.is_a?(Var) %}
+            {% var_declaration_exclusions << first_arg.stringify %}
+          {% elsif first_arg.is_a?(Call) && !first_arg.receiver && first_arg.args.empty? && first_arg.named_args.is_a?(Nop) && first_arg.block.is_a?(Nop) %}
+            {% var_declaration_exclusions << first_arg.name.stringify %}
+          {% end %}
+        {% end %}
+      {% end %}
 
       {% if opts[:nested_scope] %}
-        {% for var in exps.select { |e| e.is_a?(Assign) }.map { |a| a.target.stringify }.uniq %}
+        {% for var in exps.select { |e| e.is_a?(Assign) }.map { |a| a.target.stringify }.uniq.reject { |name| var_declaration_exclusions.includes?(name) } %}
           {{io}} << "var "
           {{io}} << {{var}}
           {{io}} << ";"
@@ -36,7 +59,68 @@ module JS
       {% end %}
 
       {% for exp in exps %}
-          {% if exp.is_a?(Call) && exp.name.stringify == "_literal_js" && !opts[:strict] %}
+          {% if exp.is_a?(Call) && !exp.receiver && (exp.name.stringify == "let" || exp.name.stringify == "const") %}
+            {% declaration_kind = exp.name.stringify %}
+            {% if exp.args.empty? %}
+              {{exp.raise "`#{declaration_kind}` requires a variable name. Use `#{declaration_kind} my_var = value`."}}
+            {% elsif exp.args.size > 2 %}
+              {{exp.raise "`#{declaration_kind}` accepts one assignment argument (`#{declaration_kind} my_var = value`) or two positional arguments (`#{declaration_kind}(my_var, value)`)."}}
+            {% end %}
+
+            {% has_initializer = false %}
+            {% declared_name = nil %}
+
+            {% if exp.args.first.is_a?(Assign) %}
+              {% assignment = exp.args.first %}
+              {% unless assignment.target.is_a?(Var) %}
+                {{assignment.raise "`#{declaration_kind}` declarations require a plain variable name on the left-hand side."}}
+              {% end %}
+              {% if exp.args.size == 2 %}
+                {{exp.raise "`#{declaration_kind}` with an assignment argument cannot also include a second value argument."}}
+              {% end %}
+              {% declared_name = assignment.target.stringify %}
+              {% has_initializer = true %}
+              {{assignment.target}} = nil
+              {% scope_declared_vars << assignment.target.stringify %}
+              {{io}} << {{declaration_kind}}
+              {{io}} << " "
+              {{io}} << {{assignment.target.stringify}}
+              {{io}} << " = "
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                {{assignment.value}}
+              end
+            {% else %}
+              {% name_arg = exp.args.first %}
+              {% if name_arg.is_a?(Var) %}
+                {% declared_name = name_arg.stringify %}
+                {{name_arg}} = nil
+              {% elsif name_arg.is_a?(Call) && !name_arg.receiver && name_arg.args.empty? && name_arg.named_args.is_a?(Nop) && name_arg.block.is_a?(Nop) %}
+                {% declared_name = name_arg.name.stringify %}
+                {{name_arg.name.id}} = nil
+              {% else %}
+                {{name_arg.raise "`#{declaration_kind}` requires a plain variable name as its first argument."}}
+              {% end %}
+
+              {% scope_declared_vars << declared_name %}
+              {{io}} << {{declaration_kind}}
+              {{io}} << " "
+              {{io}} << {{declared_name}}
+
+              {% if exp.args.size == 2 %}
+                {% has_initializer = true %}
+                {{io}} << " = "
+                JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                  {{exp.args.last}}
+                end
+              {% elsif declaration_kind == "const" %}
+                {{exp.raise "`const` requires an initializer. Use `const my_var = value` or `const(my_var, value)`."}}
+              {% end %}
+            {% end %}
+
+            {% if !opts[:inline] %}
+              {{io}} << ";"
+            {% end %}
+          {% elsif exp.is_a?(Call) && exp.name.stringify == "_literal_js" && !opts[:strict] %}
             {{io}} << {{exp.args.first}}
           {% elsif exp.is_a?(Call) && exp.name.stringify == "to_js_call" %}
             {{io}} << {{exp}}
@@ -48,7 +132,7 @@ module JS
           {% elsif exp.is_a?(Call) && !exp.receiver && exp.name.stringify == "await" %}
             {{io}} << "await "
             {% if exp.args.size > 0 %}
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                 {{exp.args.first}}
               end
             {% end %}
@@ -59,19 +143,19 @@ module JS
             {{io}} << "async function("
             {{io}} << {{exp.block.args.splat.stringify}}
             {{io}} << ") {"
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: true, strict: {{opts[:strict]}}}) {{exp.block}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: true, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) {{exp.block}}
             {{io}} << "}"
             {% if !opts[:inline] %}
               {{io}} << ";"
             {% end %}
           {% elsif exp.is_a?(Call) && exp.name.stringify == "new" %}
             {{io}} << "new "
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.receiver}}
             end
             {{io}} << "("
             {% for arg, index in exp.args %}
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                 {{arg}}
               end
               {% if index < exp.args.size - 1 %}
@@ -82,7 +166,7 @@ module JS
           {% elsif exp.is_a?(Call) && exp.name.stringify == "[]" %}
             {{io}} << {{exp.receiver.stringify}}
             {{io}} << "["
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.args.first}}
             end
             {{io}} << "]"
@@ -92,11 +176,11 @@ module JS
           {% elsif exp.is_a?(Call) && exp.name.stringify == "[]=" %}
             {{io}} << {{exp.receiver.stringify}}
             {{io}} << "["
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.args.first}}
             end
             {{io}} << "] = "
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.args.last}}
             end
             {% if !opts[:inline] %}
@@ -107,7 +191,7 @@ module JS
             {{io}} << "."
             {{io}} << {{exp.name.stringify[0..-2]}}
             {{io}} << " = "
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.args.first}}
             end
             {% if !opts[:inline] %}
@@ -115,29 +199,29 @@ module JS
             {% end %}
           {% elsif exp.is_a?(Call) %}
             {% if exp.receiver && exp.args.size == 1 && OPERATOR_CALL_NAMES.includes?(exp.name.stringify) %}
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                 {{exp.receiver}}
               end
               {{io}} << " "
               {{io}} << {{exp.name.stringify}}
               {{io}} << " "
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                 {{exp.args.first}}
               end
             {% else %}
-              {% if opts[:strict] && !exp.receiver && !JS_ALIASES.has_key?(exp.name.stringify) %}
+              {% if opts[:strict] && !exp.receiver && !JS_ALIASES.has_key?(exp.name.stringify) && !scope_declared_vars.includes?(exp.name.stringify) %}
                 JS::Context.default.{{exp.name}}
               {% end %}
               {% emitted_from_strict_context = false %}
               {% if exp.receiver %}
                 # TODO: Replace this whole `if` by a recursive call to this macro?
                 {% if exp.receiver.is_a?(Call) %}
-                  JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                  JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                     {{exp.receiver}}
                   end
                 {% elsif exp.receiver.is_a?(Expressions) %}
                   {% for rec_exp in exp.receiver.expressions %}
-                    JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                    JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                       {{rec_exp}}
                     end
                   {% end %}
@@ -153,7 +237,7 @@ module JS
                 {% if exp.name.stringify != "_call" %}
                   {{io}} << "."
                 {% end %}
-              {% elsif opts[:strict] && exp.args.empty? && exp.named_args.is_a?(Nop) && !exp.block && !JS_ALIASES.has_key?(exp.name.stringify) %}
+              {% elsif opts[:strict] && exp.args.empty? && exp.named_args.is_a?(Nop) && !exp.block && !JS_ALIASES.has_key?(exp.name.stringify) && !scope_declared_vars.includes?(exp.name.stringify) %}
                   {{io}} << JS::Context.default.{{exp.name}}.to_js_ref
                   {% emitted_from_strict_context = true %}
               {% end %}
@@ -165,7 +249,7 @@ module JS
                 {{io}} << "("
               {% end %}
               {% for arg, index in exp.args %}
-                JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                   {{arg}}
                 end
                 {% if index < exp.args.size - 1 || exp.block || has_named_args %}
@@ -177,7 +261,7 @@ module JS
                 {% for named_arg, index in exp.named_args %}
                   {{io}} << {{named_arg.name.stringify}}
                   {{io}} << ": "
-                  JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                  JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                     {{named_arg.value}}
                   end
                   {% if index < exp.named_args.size - 1 %}
@@ -193,7 +277,7 @@ module JS
                 {{io}} << "function("
                 {{io}} << {{exp.block.args.splat.stringify}}
                 {{io}} << ") {"
-                JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: true, strict: {{opts[:strict]}}}) {{exp.block}}
+                JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: true, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) {{exp.block}}
                 {{io}} << "}"
               {% end %}
               {% if exp.args.size > 0 || exp.block || exp.name.stringify == "_call" || has_named_args %}
@@ -218,7 +302,7 @@ module JS
           {% elsif exp.is_a?(ArrayLiteral) %}
             {{io}} << "["
             {% for element, index in exp %}
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                 {{element}}
               end
               {% if index < exp.size - 1 %}
@@ -234,7 +318,7 @@ module JS
             {% for key, i in exp.keys %}
               {{io}} << {{key.id.stringify}}
               {{io}} << ": "
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                 {{exp[key]}}
               end
               {% if i < exp.size - 1 %}
@@ -247,17 +331,17 @@ module JS
             {% end %}
           {% elsif exp.is_a?(If) %}
             {{io}} << "if ("
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.cond}}
             end
             {{io}} << ") {"
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.then}}
             end
             {{io}} << "}"
             {% if !exp.else.is_a?(Nop) %}
               {{io}} << " else {"
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
                 {{exp.else}}
               end
               {{io}} << "}"
@@ -266,7 +350,7 @@ module JS
             {{exp.target}} = nil
             {{io}} << {{exp.target.stringify}}
             {{io}} << " = "
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.value}}
             end
             {% if !opts[:inline] %}
@@ -274,7 +358,7 @@ module JS
             {% end %}
           {% elsif exp.is_a?(Return) %}
             {{io}} << "return "
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.exp}}
             end
             {% if !opts[:inline] %}
@@ -282,23 +366,23 @@ module JS
             {% end %}
           {% elsif exp.is_a?(ProcLiteral) %}
             {{io}} << "({{exp.args.map(&.name).splat}}) => {"
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
               {{exp.body}}
             end
             {{io}} << "}"
           {% elsif exp.is_a?(MacroIf) %}
             \{% if {{exp.cond}} %}
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}}) do
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do
                 {{exp.then}}
               end
             \{% else %}
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}}) do
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do
                 {{exp.else}}
               end
             \{% end %}
           {% elsif exp.is_a?(MacroFor) %}
             \{% for {{exp.vars.splat}} in {{exp.exp}} %}
-              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}}) do
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do
                 {{exp.body}}
               end
             \{% end %}

--- a/src/js/file.cr
+++ b/src/js/file.cr
@@ -60,7 +60,7 @@ module JS
         JS::Code._eval_js_block(
           io,
           {{namespace}},
-          {inline: false, nested_scope: true, strict: {{strict}}}
+          {inline: false, nested_scope: true, strict: {{strict}}, declared_vars: [] of String}
         ) {{blk}}
       end
 

--- a/src/js/function.cr
+++ b/src/js/function.cr
@@ -40,7 +40,7 @@ module JS
         JS::Code._eval_js_block(
           io,
           {{@type.resolve}},
-          {inline: false, nested_scope: true, strict: false}
+          {inline: false, nested_scope: true, strict: false, declared_vars: [] of String}
         ) {{blk}}
         io << "}"
       end

--- a/src/js/method.cr
+++ b/src/js/method.cr
@@ -17,7 +17,7 @@ module JS
         JS::Code._eval_js_block(
           io,
           {{@type.resolve}},
-          {inline: false, nested_scope: true, strict: false}
+          {inline: false, nested_scope: true, strict: false, declared_vars: [] of String}
         ) {{blk}}
         io << "}"
       end


### PR DESCRIPTION
## Summary
This adds explicit variable declaration primitives to the `def_to_js` DSL so generated JavaScript can use `let`/`const` at the declaration site while preserving expected Crystal-side usability in the remainder of the block.

## What changed
- Added `let` and `const` handling in `JS::Code._eval_js_block`.
- Supported declaration forms:
 - `let my_var = value`
 - `const my_var = value`
 - `let my_var` (emits `let my_var;`, Crystal local initialized as `nil`)
 - `let(my_var, value)` / `const(my_var, value)` as explicit call style
- Added compile-time validation and actionable errors for invalid declaration usage.
- Added compile-time rejection for `const` without initializer.
- Updated declaration tracking to:
 - Treat declared names as in-scope for strict-mode identifier resolution.
 - Prevent duplicate auto-predeclared `var` output when a name is explicitly declared via `let`/`const`.
- Propagated declaration tracking options through code-generation entry points (`JS::Code`, `JS::File`, `JS::Function`, `JS::Method`).

## Specs
Added `spec/js/code/declaration_spec.cr` covering:
- Motivating case: declare before `if`, assign inside branch, reference after branch.
- Emission of `let`/`const` at declaration site.
- No duplicate `var` predeclaration for explicitly declared names.
- Strict-mode usage of declared variables.
- Compile-time failure for `const` without initializer.

## Validation
- `crystal spec`
- `crystal tool format --check src spec`