### PR TITLE
Add fragment composition support for JS::File

### DIFF
--- a/spec/js/file/fragment_composition_spec.cr
+++ b/spec/js/file/fragment_composition_spec.cr
@@ -1,0 +1,71 @@
+require "../../spec_helper"
+
+module JS::File::FragmentCompositionSpec
+  class MultiFragmentFile < JS::File
+    js_fragment do
+      console.log("first fragment")
+    end
+
+    js_fragment do
+      console.log("second fragment")
+    end
+  end
+
+  class ReopenedFragmentFile < JS::File
+    js_fragment do
+      console.log("scope-a")
+    end
+  end
+
+  class ReopenedFragmentFile
+    js_fragment do
+      console.log("scope-b")
+    end
+  end
+
+  class FunctionAndFragmentFile < JS::File
+    js_function :log_scope do |scope|
+      console.log(scope)
+    end
+
+    js_fragment do
+      log_scope("scope-a")
+    end
+
+    def_to_js do
+      log_scope("scope-b")
+    end
+  end
+
+  describe "fragment composition in JS::File" do
+    it "emits multiple fragments in deterministic declaration order" do
+      expected = <<-JS.squish
+      console.log("first fragment");
+      console.log("second fragment");
+      JS
+
+      MultiFragmentFile.to_js.should eq(expected)
+    end
+
+    it "supports reopen-style fragment contributions from different call sites" do
+      expected = <<-JS.squish
+      console.log("scope-a");
+      console.log("scope-b");
+      JS
+
+      ReopenedFragmentFile.to_js.should eq(expected)
+    end
+
+    it "keeps js_function and def_to_js compatible with fragment composition" do
+      expected = <<-JS.squish
+      function log_scope(scope) {
+        console.log(scope);
+      }
+      log_scope("scope-a");
+      log_scope("scope-b");
+      JS
+
+      FunctionAndFragmentFile.to_js.should eq(expected)
+    end
+  end
+end

--- a/src/js/file.cr
+++ b/src/js/file.cr
@@ -79,16 +79,13 @@ module JS
     end
 
     macro _register_js_fragment(namespace, strict = false, &blk)
-      {% fragment_method = "__js_fragment_line_#{blk.line_number}_col_#{blk.column_number}".id %}
-      def self.{{fragment_method}}(io : IO)
+      @@js_fragments << ->(io : IO) do
         JS::Code._eval_js_block(
           io,
           {{namespace}},
           {inline: false, nested_scope: true, strict: {{strict}}, declared_vars: [] of String}
         ) {{blk}}
       end
-
-      @@js_fragments << ->(io : IO) { {{fragment_method}}(io) }
     end
   end
 end

--- a/src/js/file.cr
+++ b/src/js/file.cr
@@ -6,6 +6,27 @@ module JS
   abstract class File
     @@js_classes = [] of JS::Class.class
     @@js_functions = [] of JS::Function.class
+    @@js_fragments = [] of Proc(IO, Nil)
+
+    # Base file emission includes class/function declarations plus all
+    # registered JS fragments in declaration order.
+    def self.to_js(io : IO)
+      @@js_classes.each do |js_class|
+        js_class.to_js(io)
+      end
+      @@js_functions.each do |func|
+        func.to_js(io)
+      end
+      @@js_fragments.each do |fragment|
+        fragment.call(io)
+      end
+    end
+
+    def self.to_js
+      String.build do |str|
+        to_js(str)
+      end
+    end
 
     macro js_alias(new_name, old_name)
       JS::Code.js_alias({{new_name}}, {{old_name}})
@@ -45,18 +66,21 @@ module JS
       end
     end
 
+    macro js_fragment(strict = false, &blk)
+      _register_js_fragment({{@type}}, strict: {{strict}}) {{blk}}
+    end
+
     macro def_to_js(strict = false, &blk)
-      def_to_js({{@type}}, strict: {{strict}}) {{blk}}
+      _register_js_fragment({{@type}}, strict: {{strict}}) {{blk}}
     end
 
     macro def_to_js(namespace, strict = false, &blk)
-      def self.to_js(io : IO)
-        @@js_classes.each do |js_class|
-          js_class.to_js(io)
-        end
-        @@js_functions.each do |func|
-          func.to_js(io)
-        end
+      _register_js_fragment({{namespace}}, strict: {{strict}}) {{blk}}
+    end
+
+    macro _register_js_fragment(namespace, strict = false, &blk)
+      {% fragment_method = "__js_fragment_line_#{blk.line_number}_col_#{blk.column_number}".id %}
+      def self.{{fragment_method}}(io : IO)
         JS::Code._eval_js_block(
           io,
           {{namespace}},
@@ -64,11 +88,7 @@ module JS
         ) {{blk}}
       end
 
-      def self.to_js
-        String.build do |str|
-          to_js(str)
-        end
-      end
+      @@js_fragments << ->(io : IO) { {{fragment_method}}(io) }
     end
   end
 end

--- a/src/js/module.cr
+++ b/src/js/module.cr
@@ -4,17 +4,17 @@ module JS
   abstract class Module < JS::File
     @@js_imports = [] of String
 
+    def self.to_js(io : IO)
+      @@js_imports.join(io, "\n")
+      super(io)
+    end
+
     macro js_import(*names, from)
       @@js_imports << ("import { {{names.map(&.id).splat}} } from \"" + {{from}} + "\";")
     end
 
     macro def_to_js(strict = false, &blk)
       JS::File.def_to_js({{@type}}, strict: {{strict}}) {{blk}}
-
-      def self.to_js(io : IO)
-        @@js_imports.join(io, "\n")
-        previous_def
-      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Adds fragment composition to `JS::File` so multiple independent JS contributions can be appended into a single file output in deterministic order, including reopen-style class usage.

## Changes
- Added a new `js_fragment` macro on `JS::File` for explicit fragment contribution.
- Refactored `JS::File` emission to:
 - keep `js_class` and `js_function` output,
 - append registered fragments in declaration order.
- Kept `def_to_js` compatible by routing it through the same fragment registration path.
- Updated `JS::Module` output wrapping to use `super(io)` for compatibility with the new file-level composition flow.
- Added specs in `spec/js/file/fragment_composition_spec.cr` to cover:
 - deterministic ordering of multiple fragments,
 - reopen-style fragment contribution ordering,
 - compatibility when combining `js_function`, `js_fragment`, and `def_to_js`.

## Validation
- `crystal tool format --check src spec`
- `CRYSTAL_CACHE_DIR=/tmp/.crystal-cache-js crystal spec` (56 examples, 0 failures)