### PR TITLE
Generate JavaScript ternaries for conditional expressions

### DIFF
--- a/spec/js/code/if_else_spec.cr
+++ b/spec/js/code/if_else_spec.cr
@@ -31,6 +31,21 @@ module JS::Code::IfElseSpec
     end
   end
 
+  class ConditionalExpressionCode < JS::Code
+    def_to_js do
+      index = if event.params.placement == "bottom"
+                1
+              else
+                0
+              end
+      let label = enabled ? "enabled" : "disabled"
+      console.log(ready ? result : fallback)
+      optional = if available
+                   value
+                 end
+    end
+  end
+
   describe "MyCode.to_js" do
     it "should return the correct JS code" do
       expected = <<-JS.squish
@@ -66,6 +81,22 @@ module JS::Code::IfElseSpec
       JS
 
       MyCode.to_js.should eq(expected)
+    end
+  end
+
+  describe "ConditionalExpressionCode.to_js" do
+    it "emits JavaScript conditional operators when Crystal conditionals are used as expressions" do
+      expected = <<-JS.squish
+      var index;
+      var optional;
+      index = (event.params.placement == "bottom" ? 1 : 0);
+      let label = (enabled ? "enabled" : "disabled");
+      console.log((ready ? result : fallback));
+      optional = (available ? value : undefined);
+      JS
+
+      ConditionalExpressionCode.to_js.should eq(expected)
+      ConditionalExpressionCode.to_js.should_not contain("= if (")
     end
   end
 end

--- a/src/js/code.cr
+++ b/src/js/code.cr
@@ -368,21 +368,43 @@ module JS
               {{io}} << ";"
             {% end %}
           {% elsif exp.is_a?(If) %}
-            {{io}} << "if ("
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
-              {{exp.cond}}
-            end
-            {{io}} << ") {"
-            JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
-              {{exp.then}}
-            end
-            {{io}} << "}"
-            {% if !exp.else.is_a?(Nop) %}
-              {{io}} << " else {"
+            {% if opts[:inline] %}
+              # Crystal conditionals are expressions, so emit JavaScript's
+              # conditional operator when the result is used inline.
+              {{io}} << "("
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                {{exp.cond}}
+              end
+              {{io}} << " ? "
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                {{exp.then}}
+              end
+              {{io}} << " : "
+              {% if exp.else.is_a?(Nop) %}
+                {{io}} << "undefined"
+              {% else %}
+                JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                  {{exp.else}}
+                end
+              {% end %}
+              {{io}} << ")"
+            {% else %}
+              {{io}} << "if ("
+              JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: true, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                {{exp.cond}}
+              end
+              {{io}} << ") {"
               JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
-                {{exp.else}}
+                {{exp.then}}
               end
               {{io}} << "}"
+              {% if !exp.else.is_a?(Nop) %}
+                {{io}} << " else {"
+                JS::Code._eval_js_block({{io}}, {{namespace}}, {inline: false, nested_scope: false, strict: {{opts[:strict]}}, declared_vars: {{scope_declared_vars.empty? ? "[] of String".id : scope_declared_vars}}}) do {{blk.args.empty? ? "".id : "|#{blk.args.splat}|".id}}
+                  {{exp.else}}
+                end
+                {{io}} << "}"
+              {% end %}
             {% end %}
           {% elsif exp.is_a?(Assign) %}
             {{exp.target}} = nil


### PR DESCRIPTION
## Summary
- Emit JavaScript conditional operators for inline Crystal conditionals
- Preserve statement-level `if/else` generation
- Emit `undefined` when an inline conditional lacks an `else`

## Testing
- `crystal spec --error-trace`
- `crystal tool format --check src spec`